### PR TITLE
Convert echo ws demo server to chat ws demo server; add board model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
 # don't track emacs tmp files
 *~
+\#*
 
+# don't track virtual env stuff
 venv
+
+# don't track intellij-related files
+.idea/*
+*.iml
+

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ venv
 .idea/*
 *.iml
 
+# don't track compiled python files
+*.pyc

--- a/server/models/board.py
+++ b/server/models/board.py
@@ -18,8 +18,8 @@ class Board(object):
     def __init__(self, rows, cols):
         self.rows = rows
         self.cols = cols
-        self.edges = {}  # maps edges to edge owner (board[p1][p2] = Owner)
-        self.boxes = {}  # maps top-left point of each box to box owner
+        self._edges = {}  # maps edges to edge owner (board[p1][p2] = Owner)
+        self._boxes = {}  # maps top-left point of each box to box owner
 
         self._reset_board()
 
@@ -29,20 +29,49 @@ class Board(object):
     '' Adds unowned edges to each possible position on the board
     '''
     def _reset_board(self):
-        self.boxes = {}
+        self._boxes = {}
         for r in range(0, self.rows):
             for c in range(0, self.cols):
 
-                if not (r, c) in self.edges:
-                    self.edges[(r, c)] = {}
+                if not (r, c) in self._edges:
+                    self._edges[(r, c)] = {}
 
                 # add an un-owned edge from the current node to the node below and to the right
                 # do not add an edge that goes out of bounds (r + 1 exceeds rows, c + 1 exceeds cols)
                 if not c == self.cols - 1:
-                    self.edges[(r, c)][(r, c + 1)] = None
+                    self._edges[(r, c)][(r, c + 1)] = None
 
                 if not r == self.rows - 1:
-                    self.edges[(r, c)][(r + 1, c)] = None
+                    self._edges[(r, c)][(r + 1, c)] = None
+
+    '''
+    '' Returns the owner of the edge (p1, p2)
+    ''  p1:     A tuple describing source node (row, col)
+    ''  p2:     A tuple describing target node (row, col)
+    ''
+    ''  Returns the owner of the edge, or None if the edge is unowned
+    '''
+    def get_edge_owner(self, p1, p2):
+
+        if len(p1) != 2 or len(p2) != 2:
+            raise ValueError("A point was not a tuple of len 2: {}, {}".format(p1, p2))
+
+        if not self._is_valid_edge(p1, p2):
+            raise ValueError("Edge is not valid:  {}, {}".format(str(p1), str(p2)))
+
+        p1, p2 = self._coerce_points(p1, p2)
+
+        return self._edges[p1][p2]
+
+    '''
+    '' Returns True if the edge (p1, p2) is owned
+    ''  p1:     A tuple describing source node (row, col)
+    ''  p2:     A tuple describing target node (row, col)
+    ''
+    ''  Returns the owner of the edge, or None if the edge is unowned
+    '''
+    def edge_is_owned(self, p1, p2):
+        return self.get_edge_owner(p1, p2) is not None
 
     '''
     '' Claims an unowned edge from p1 to p2
@@ -69,15 +98,15 @@ class Board(object):
             raise ValueError("Edge is not valid:  {}, {}".format(str(p1), str(p2)))
 
         p1, p2 = self._coerce_points(p1, p2)
-        if p1 not in self.edges:
-            self.edges[p1] = {}
+        if p1 not in self._edges:
+            self._edges[p1] = {}
 
-        if self.edges[p1][p2]:
+        if self._edges[p1][p2]:
             raise
 
         created_boxes = self._get_new_boxes(p1, p2)
 
-        self.edges[p1][p2] = owner
+        self._edges[p1][p2] = owner
 
         # TODO:  implement _get_new_boxes
         # for box in created_boxes:

--- a/server/models/board.py
+++ b/server/models/board.py
@@ -8,6 +8,8 @@
 '    { sourcePoint1: {neighboringPoint1: owner, neighboringPoint2: owner}, sourcePoint2: ... }
 '
 '    where each point is a row-majored tuple of 2 integers describing the row and column of the point.
+'
+'  completed boxes are maintained in a map mapping the top-left corner of the box to the owner of the box
 """
 
 

--- a/server/models/board.py
+++ b/server/models/board.py
@@ -18,8 +18,8 @@ class Board(object):
     def __init__(self, rows, cols):
         self.rows = rows
         self.cols = cols
-        self._edges = {}  # maps edges to edge owner (board[p1][p2] = Owner)
-        self._boxes = {}  # maps top-left point of each box to box owner
+        self.__edges = {}  # maps edges to edge owner (board[p1][p2] = Owner)
+        self.__boxes = {}  # maps top-left point of each box to box owner
 
         self._reset_board()
 
@@ -29,20 +29,20 @@ class Board(object):
     '' Adds unowned edges to each possible position on the board
     '''
     def _reset_board(self):
-        self._boxes = {}
+        self.__boxes = {}
         for r in range(0, self.rows):
             for c in range(0, self.cols):
 
-                if not (r, c) in self._edges:
-                    self._edges[(r, c)] = {}
+                if not (r, c) in self.__edges:
+                    self.__edges[(r, c)] = {}
 
                 # add an un-owned edge from the current node to the node below and to the right
                 # do not add an edge that goes out of bounds (r + 1 exceeds rows, c + 1 exceeds cols)
                 if not c == self.cols - 1:
-                    self._edges[(r, c)][(r, c + 1)] = None
+                    self.__edges[(r, c)][(r, c + 1)] = None
 
                 if not r == self.rows - 1:
-                    self._edges[(r, c)][(r + 1, c)] = None
+                    self.__edges[(r, c)][(r + 1, c)] = None
 
     '''
     '' Returns the owner of the edge (p1, p2)
@@ -56,12 +56,12 @@ class Board(object):
         if len(p1) != 2 or len(p2) != 2:
             raise ValueError("A point was not a tuple of len 2: {}, {}".format(p1, p2))
 
-        if not self._is_valid_edge(p1, p2):
+        if not self.__is_valid_edge(p1, p2):
             raise ValueError("Edge is not valid:  {}, {}".format(str(p1), str(p2)))
 
-        p1, p2 = self._coerce_points(p1, p2)
+        p1, p2 = self.__coerce_points(p1, p2)
 
-        return self._edges[p1][p2]
+        return self.__edges[p1][p2]
 
     '''
     '' Returns True if the edge (p1, p2) is owned
@@ -81,7 +81,7 @@ class Board(object):
     ''  player: the owner of the new edge
     ''
     ''  This implementation coerces the source node to always be above or to the left of the destination node
-    ''    eg: if claim_edge((1, 1), (0, 1), PLAYER) is called, board[(0, 1)][(1, 1)] is assigned to PLAYER
+    ''    eg: if claim_edge((1, 1), (0, 1), PLAYER) is called, edges[(0, 1)][(1, 1)] is assigned to PLAYER
     ''
     ''  Raises an ValueError if the edge is already owned
     ''  Raises a ValueError if the edge isn't between two adjacent nodes
@@ -94,19 +94,19 @@ class Board(object):
         if not owner:
             raise ValueError("Owner should not be None")
 
-        if not self._is_valid_edge(p1, p2):
+        if not self.__is_valid_edge(p1, p2):
             raise ValueError("Edge is not valid:  {}, {}".format(str(p1), str(p2)))
 
-        p1, p2 = self._coerce_points(p1, p2)
-        if p1 not in self._edges:
-            self._edges[p1] = {}
+        p1, p2 = self.__coerce_points(p1, p2)
+        if p1 not in self.__edges:
+            self.__edges[p1] = {}
 
-        if self._edges[p1][p2]:
+        if self.__edges[p1][p2]:
             raise
 
-        created_boxes = self._get_new_boxes(p1, p2)
+        created_boxes = self.__get_new_boxes(p1, p2)
 
-        self._edges[p1][p2] = owner
+        self.__edges[p1][p2] = owner
 
         # TODO:  implement _get_new_boxes
         # for box in created_boxes:
@@ -120,7 +120,7 @@ class Board(object):
     ''
     ''  Throws an ValueError if the edge already exists on the board
     '''
-    def _get_new_boxes(self, p1, p2):
+    def __get_new_boxes(self, p1, p2):
         pass
 
     '''
@@ -128,7 +128,7 @@ class Board(object):
     ''    That is to say, returns True if the two points provided are immediately adjacent to each other
     '''
     @staticmethod
-    def _is_valid_edge(p1, p2):
+    def __is_valid_edge(p1, p2):
 
         # if the difference in two points' x is 1 or -1   XOR
         # the difference in two points' y is 1 or -1, then the points are either immediately above or beside each other
@@ -140,7 +140,7 @@ class Board(object):
     ''    Otherwise returns p2, p1
     '''
     @staticmethod
-    def _coerce_points(p1, p2):
+    def __coerce_points(p1, p2):
 
         if p1[0] == p2[0]:
             if p1[1] < p2[1]:

--- a/server/models/board.py
+++ b/server/models/board.py
@@ -1,0 +1,125 @@
+"""
+'  Class modeling a box game board
+'
+'  rows:  number of rows in the grid
+'  cols:  number of columns in the grid
+'
+'  edges are maintained in a map of maps with the following structure:
+'    { sourcePoint1: {neighboringPoint1: owner, neighboringPoint2: owner}, sourcePoint2: ... }
+'
+'    where each point is a row-majored tuple of 2 integers describing the row and column of the point.
+"""
+
+
+class Board(object):
+
+    def __init__(self, rows, cols):
+        self.rows = rows
+        self.cols = cols
+        self.edges = {}  # maps edges to edge owner (board[p1][p2] = Owner)
+        self.boxes = {}  # maps top-left point of each box to box owner
+
+        self._reset_board()
+
+    '''
+    '' Resets the board and box maps
+    ''
+    '' Adds unowned edges to each possible position on the board
+    '''
+    def _reset_board(self):
+        self.boxes = {}
+        for r in range(0, self.rows):
+            for c in range(0, self.cols):
+
+                if not (r, c) in self.edges:
+                    self.edges[(r, c)] = {}
+
+                # add an un-owned edge from the current node to the node below and to the right
+                # do not add an edge that goes out of bounds (r + 1 exceeds rows, c + 1 exceeds cols)
+                if not c == self.cols - 1:
+                    self.edges[(r, c)][(r, c + 1)] = None
+
+                if not r == self.rows - 1:
+                    self.edges[(r, c)][(r + 1, c)] = None
+
+    '''
+    '' Claims an unowned edge from p1 to p2
+    ''
+    ''  p1:     A tuple describing source node (row, col)
+    ''  p2:     A tuple describing target node (row, col)
+    ''  player: the owner of the new edge
+    ''
+    ''  This implementation coerces the source node to always be above or to the left of the destination node
+    ''    eg: if claim_edge((1, 1), (0, 1), PLAYER) is called, board[(0, 1)][(1, 1)] is assigned to PLAYER
+    ''
+    ''  Raises an ValueError if the edge is already owned
+    ''  Raises a ValueError if the edge isn't between two adjacent nodes
+    '''
+    def claim_edge(self, p1, p2, owner):
+
+        if len(p1) != 2 or len(p2) != 2:
+            raise ValueError("A point was not a tuple of len 2: {}, {}".format(p1, p2))
+
+        if not owner:
+            raise ValueError("Owner should not be None")
+
+        if not self._is_valid_edge(p1, p2):
+            raise ValueError("Edge is not valid:  {}, {}".format(str(p1), str(p2)))
+
+        p1, p2 = self._coerce_points(p1, p2)
+        if p1 not in self.edges:
+            self.edges[p1] = {}
+
+        if self.edges[p1][p2]:
+            raise
+
+        created_boxes = self._get_new_boxes(p1, p2)
+
+        self.edges[p1][p2] = owner
+
+        # TODO:  implement _get_new_boxes
+        # for box in created_boxes:
+        #     self.boxes[box] = owner
+
+    '''
+    '' Returns the list of boxes that would be made by adding a line
+    ''
+    ''  p1: a tuple describing source node (row, col)
+    ''  p2: a tuple describing target node (row, col)
+    ''
+    ''  Throws an ValueError if the edge already exists on the board
+    '''
+    def _get_new_boxes(self, p1, p2):
+        pass
+
+    '''
+    ''  Returns True if a valid edge could possibly exist between two points
+    ''    That is to say, returns True if the two points provided are immediately adjacent to each other
+    '''
+    @staticmethod
+    def _is_valid_edge(p1, p2):
+
+        # if the difference in two points' x is 1 or -1   XOR
+        # the difference in two points' y is 1 or -1, then the points are either immediately above or beside each other
+        return bool(abs(p1[0] - p2[0]) == 1) ^ bool(abs(p1[1] - p2[1]) == 1)
+
+    '''
+    '' Returns the proper ordering of p1 and p2.
+    ''    If p1 is above p2 or p1 is to the left of p2, returns p1, p2.
+    ''    Otherwise returns p2, p1
+    '''
+    @staticmethod
+    def _coerce_points(p1, p2):
+
+        if p1[0] == p2[0]:
+            if p1[1] < p2[1]:
+                return p1, p2
+            return p2, p1
+
+        if p1[1] == p2[1]:
+            if p1[0] < p2[0]:
+                return p1, p2
+
+            return p2, p1
+
+        raise ValueError("Either row or column must match: {}, {}".format(p1, p2))

--- a/server/models/board.py
+++ b/server/models/board.py
@@ -16,8 +16,8 @@
 class Board(object):
 
     def __init__(self, rows, cols):
-        self.rows = rows
-        self.cols = cols
+        self.__rows = rows
+        self.__cols = cols
         self.__edges = {}  # maps edges to edge owner (board[p1][p2] = Owner)
         self.__boxes = {}  # maps top-left point of each box to box owner
 
@@ -30,18 +30,18 @@ class Board(object):
     '''
     def _reset_board(self):
         self.__boxes = {}
-        for r in range(0, self.rows):
-            for c in range(0, self.cols):
+        for r in range(0, self.__rows):
+            for c in range(0, self.__cols):
 
                 if not (r, c) in self.__edges:
                     self.__edges[(r, c)] = {}
 
                 # add an un-owned edge from the current node to the node below and to the right
                 # do not add an edge that goes out of bounds (r + 1 exceeds rows, c + 1 exceeds cols)
-                if not c == self.cols - 1:
+                if not c == self.__cols - 1:
                     self.__edges[(r, c)][(r, c + 1)] = None
 
-                if not r == self.rows - 1:
+                if not r == self.__rows - 1:
                     self.__edges[(r, c)][(r + 1, c)] = None
 
     '''
@@ -80,11 +80,13 @@ class Board(object):
     ''  p2:     A tuple describing target node (row, col)
     ''  player: the owner of the new edge
     ''
+    ''  Returns:  the list of boxes created by claiming an edge
+    ''
     ''  This implementation coerces the source node to always be above or to the left of the destination node
     ''    eg: if claim_edge((1, 1), (0, 1), PLAYER) is called, edges[(0, 1)][(1, 1)] is assigned to PLAYER
     ''
-    ''  Raises an ValueError if the edge is already owned
-    ''  Raises a ValueError if the edge isn't between two adjacent nodes
+    ''  Raises an EdgeOwnedError if the edge is already owned
+    ''  Raises a ValueError if the edge is invalid or owner is None
     '''
     def claim_edge(self, p1, p2, owner):
 
@@ -97,20 +99,19 @@ class Board(object):
         if not self.__is_valid_edge(p1, p2):
             raise ValueError("Edge is not valid:  {}, {}".format(str(p1), str(p2)))
 
-        p1, p2 = self.__coerce_points(p1, p2)
-        if p1 not in self.__edges:
-            self.__edges[p1] = {}
+        if self.edge_is_owned(p1, p2):
+            raise EdgeOwnedError()
 
-        if self.__edges[p1][p2]:
-            raise
+        p1, p2 = self.__coerce_points(p1, p2)
 
         created_boxes = self.__get_new_boxes(p1, p2)
 
         self.__edges[p1][p2] = owner
 
-        # TODO:  implement _get_new_boxes
-        # for box in created_boxes:
-        #     self.boxes[box] = owner
+        for box in created_boxes:
+            self.__boxes[box] = owner
+
+        return created_boxes
 
     '''
     '' Returns the list of boxes that would be made by adding a line
@@ -121,17 +122,103 @@ class Board(object):
     ''  Throws an ValueError if the edge already exists on the board
     '''
     def __get_new_boxes(self, p1, p2):
-        pass
+
+        if not self.__is_valid_edge(p1, p2):
+            raise ValueError("Edge is not valid:  {}, {}".format(str(p1), str(p2)))
+
+        if self.edge_is_owned(p1, p2):
+            raise ValueError("Edge is already owned:  {}, {}".format(str(p1), str(p2)))
+
+        new_boxes = []
+
+        # coerce p1, p2 so that p1 is either the top point or the left point in this line
+        p1, p2 = self.__coerce_points(p1, p2)
+
+        # if added edge is vertical
+        if p2[0] - p1[0] == 1:
+
+            # check if boxes exist to the left or right
+
+            lbtp = self.__left_neighbor(p1)     # lbtp = left box top point
+            lbbp = self.__left_neighbor(p2)     # lbbp = left box bottom point
+            rbtp = self.__right_neighbor(p1)    # rbtp = right box top point
+            rbbp = self.__right_neighbor(p2)    # rbbp = right box bottom point
+
+            #  lbtp --- p1 --- rbtp
+            #    |      | <--new |
+            #  lbbp --- p2 --- rbbp
+            #
+            #  potential new boxes have top-left corners at [lbtp, p1]
+
+            # check if the 3 lines necessary for a new box to exist are there
+
+            if (self.__is_valid_edge(lbtp, p1) and self.edge_is_owned(lbtp, p1)) and \
+                (self.__is_valid_edge(lbbp, p2) and self.edge_is_owned(lbbp, p2))and \
+                (self.__is_valid_edge(lbtp, lbbp) and self.edge_is_owned(lbtp, lbbp)):
+
+                new_boxes.append(lbtp)
+
+            # check if the 3 lines necessary for a new box to exist are there
+            if (self.__is_valid_edge(p1, rbtp) and self.edge_is_owned(p1, rbtp)) and \
+                    (self.__is_valid_edge(p2, rbbp) and self.edge_is_owned(p2, rbbp))and \
+                    (self.__is_valid_edge(rbtp, rbbp) and self.edge_is_owned(rbtp, rbbp)):
+
+                new_boxes.append(p1)
+
+            return new_boxes
+
+        elif p2[1] - p1[1] == 1:
+
+            # check if boxes exist above or below
+
+            tblp = self.__top_neighbor(p1)      # tblp = top box left point
+            tbrp = self.__top_neighbor(p2)      # tbrp = tob box right point
+            bblp = self.__bottom_neighbor(p1)   # bblp = bottom box left point
+            bbrp = self.__bottom_neighbor(p2)   # bbrp = bottom box right point
+
+            #  tblp --- tbrp
+            #    |       |
+            #    p1 -n-  p2
+            #    |       |
+            #  bblp ---  bbrp
+            #
+            #  potential new boxes have top-left corners at [tblp, p1]
+
+            # check if the 3 lines necessary for a new box to exist are there
+            if (self.__is_valid_edge(tblp, p1) and self.edge_is_owned(tblp, p1)) and \
+                    (self.__is_valid_edge(tbrp, p2) and self.edge_is_owned(tbrp, p2))and \
+                    (self.__is_valid_edge(tblp, tbrp and self.edge_is_owned(tblp, tbrp))):
+
+                new_boxes.append(tblp)
+
+            # check if the 3 lines necessary for a new box to exist are there
+            if (self.__is_valid_edge(p1, bblp) and self.edge_is_owned(p1, bblp)) and \
+                    (self.__is_valid_edge(p2, bbrp) and self.edge_is_owned(p2, bbrp))and \
+                    (self.__is_valid_edge(bblp, bbrp and self.edge_is_owned(bblp, bbrp))):
+
+                new_boxes.append(p1)
+
+            return new_boxes
 
     '''
     ''  Returns True if a valid edge could possibly exist between two points
-    ''    That is to say, returns True if the two points provided are immediately adjacent to each other
+    ''    That is to say, returns True if the two points provided are in bounds/immediately adjacent to each other
     '''
-    @staticmethod
-    def __is_valid_edge(p1, p2):
+    def __is_valid_edge(self, p1, p2):
 
         # if the difference in two points' x is 1 or -1   XOR
         # the difference in two points' y is 1 or -1, then the points are either immediately above or beside each other
+        try:
+            p1, p2 = self.__coerce_points(p1, p2)
+        except ValueError:
+            return False
+
+        if p1[0] < 0 or p1[1] < 0 or p1[0] > self.__rows or p1[1] > self.__cols:
+            return False
+
+        if p2[0] < 0 or p2[1] < 0 or p2[0] > self.__rows or p2[1] > self.__cols:
+            return False
+
         return bool(abs(p1[0] - p2[0]) == 1) ^ bool(abs(p1[1] - p2[1]) == 1)
 
     '''
@@ -154,3 +241,45 @@ class Board(object):
             return p2, p1
 
         raise ValueError("Either row or column must match: {}, {}".format(p1, p2))
+
+    def get_rows(self):
+        return self.__rows
+
+    def get_cols(self):
+        return self.__cols
+
+    """
+    ' For now, returns a list of tuples where the first item is the point indicating the top-left corner of the box
+    ' and the second item is the owner of the box
+    """
+    def get_boxes(self):
+        boxes = []
+        for (point, owner) in self.__boxes.iteritems():
+            boxes.append((point, owner))
+
+        return boxes
+
+    @staticmethod
+    def __left_neighbor(point):
+        left = (point[0], point[1] - 1)
+        return left
+
+    @staticmethod
+    def __right_neighbor(point):
+        right = (point[0], point[1] + 1)
+        return right
+
+    @staticmethod
+    def __top_neighbor(point):
+        top = (point[0] - 1, point[1])
+        return top
+
+    @staticmethod
+    def __bottom_neighbor(point):
+        bottom = (point[0] + 1, point[1])
+        return bottom
+
+
+class EdgeOwnedError(Exception):
+    def __init__(self):
+        pass

--- a/server/models/board_test.py
+++ b/server/models/board_test.py
@@ -1,0 +1,41 @@
+
+# TODO:  make this an actual unit test file
+
+from board import Board
+
+
+def main():
+
+    b = Board(5, 4)
+
+    assert b.get_rows() == 5
+    assert b.get_cols() == 4
+
+    b.claim_edge((0, 0), (0, 1), 'sam')
+    b.claim_edge((1, 0), (0, 0), 'sam')
+
+    assert b.get_edge_owner((0, 0), (1, 0)) == 'sam'  # previous addition should have coerced via rows
+
+    b.claim_edge((1, 0), (1, 1), 'sam')
+    b.claim_edge((1, 2), (1, 1), 'sam')
+
+    assert b.get_edge_owner((1, 1), (1, 2)) == 'sam'  # previous addition should have coerced via cols
+
+    b.claim_edge((0, 1), (0, 2), 'sam')
+    b.claim_edge((0, 2), (1, 2), 'sam')
+
+    assert b.claim_edge((0, 1), (1, 1), 'sam') == [(0, 0), (0, 1)]  # should create two boxes
+
+    assert len(b.get_boxes()) == 2
+    assert ((0, 0), 'sam') in b.get_boxes()
+    assert ((0, 1), 'sam') in b.get_boxes()
+
+    # todo:
+    #  test adding an invalid line, ensuring board throws an error
+    #  test creating a box where the final edge was added on the board boundary (make sure get_new_boxes handles that)
+    #  should prolly actually unit test this whole bad boy...
+
+    return 0
+
+if __name__ == '__main__':
+    main()

--- a/server/server.py
+++ b/server/server.py
@@ -6,6 +6,8 @@ import tornado.template
 # WS_HANDLERS maintains a list of currently-opened ws connections
 WS_HANDLERS = []
 
+# maintain message history for new connections
+MESSAGE_HISTORY = []
 
 class MainHandler(tornado.web.RequestHandler):
     def get(self):
@@ -21,20 +23,24 @@ class WSHandler(tornado.websocket.WebSocketHandler):
     def open(self):
         print 'connection opened.'
         WS_HANDLERS.append(self)
-        self.write_message("The server says Hello")
+        self.write_message("The server graciously welcomes you.")
+        self.write_message("Here are the past messages...")
+        for message in MESSAGE_HISTORY:
+            self.write_message(message)
 
     def on_message(self, message):
 
         # iterate over our list of connections and forward the message to each
         for ws_handler in WS_HANDLERS:
 
-            # if the connection we're about to send to is the one who sent the message
+            # if the connection we're about to send to is the one who sent the message...
             if ws_handler is self:
-                name = "You"  # refer to the client as "you"
+                name = "You"       # ...refer to the client as "you"
             else:
-                name = "A client"  # refer to the client as "A client"
+                name = "A client"  # otherwise refer to the client as "A client"
 
-            ws_handler.write_message("{} said:  {}".format(name, message))
+            MESSAGE_HISTORY.append("Past message:  {}".format(message))     # add the message to history
+            ws_handler.write_message("{} said:  {}".format(name, message))  # send the message.
 
         print 'message received:  {}'.format(message)
 
@@ -49,9 +55,9 @@ class WSHandler(tornado.websocket.WebSocketHandler):
 
 
 application = tornado.web.Application([
-    (r'/ws', WSHandler),
-    (r'/', MainHandler),
-    (r"/(.*)", tornado.web.StaticFileHandler, {"path": "./resources"}),
+    (r'/ws', WSHandler),  # endpoint for handling websocket connections
+    (r'/', MainHandler),  # endpoint for general entry
+    (r"/(.*)", tornado.web.StaticFileHandler, {"path": "./resources"}),  # still working out what this bad boy is.
 ])
 
 if __name__ == "__main__":

--- a/server/server.py
+++ b/server/server.py
@@ -3,32 +3,58 @@ import tornado.web
 import tornado.websocket
 import tornado.template
 
+# WS_HANDLERS maintains a list of currently-opened ws connections
+WS_HANDLERS = []
+
+
 class MainHandler(tornado.web.RequestHandler):
-  def get(self):
-    loader = tornado.template.Loader(".")
-    self.write(loader.load("../client/index.html").generate())
+    def get(self):
+        loader = tornado.template.Loader(".")
+        self.write(loader.load("../client/index.html").generate())
+
 
 class WSHandler(tornado.websocket.WebSocketHandler):
-  def check_origin(self, origin):
-    return True
 
-  def open(self):
-    print 'connection opened...'
-    self.write_message("The server says: 'Hello'. Connection was accepted.")
+    def check_origin(self, origin):
+        return True
 
-  def on_message(self, message):
-    self.write_message("The server says: " + message + " back at you")
-    print 'received:', message
+    def open(self):
+        print 'connection opened.'
+        WS_HANDLERS.append(self)
+        self.write_message("The server says Hello")
 
-  def on_close(self):
-    print 'connection closed...'
+    def on_message(self, message):
+
+        # iterate over our list of connections and forward the message to each
+        for ws_handler in WS_HANDLERS:
+
+            # if the connection we're about to send to is the one who sent the message
+            if ws_handler is self:
+                name = "You"  # refer to the client as "you"
+            else:
+                name = "A client"  # refer to the client as "A client"
+
+            ws_handler.write_message("{} said:  {}".format(name, message))
+
+        print 'message received:  {}'.format(message)
+
+    def on_close(self):
+        WS_HANDLERS.remove(self)  # remove the closed connection from our list of handlers
+
+        # let the other clients know someone left
+        for ws_handler in WS_HANDLERS:
+            ws_handler.write_message('somebody left')
+
+        print 'connection closed...'
+
 
 application = tornado.web.Application([
-  (r'/ws', WSHandler),
-  (r'/', MainHandler),
-  (r"/(.*)", tornado.web.StaticFileHandler, {"path": "./resources"}),
+    (r'/ws', WSHandler),
+    (r'/', MainHandler),
+    (r"/(.*)", tornado.web.StaticFileHandler, {"path": "./resources"}),
 ])
 
 if __name__ == "__main__":
-  application.listen(9090)
-  tornado.ioloop.IOLoop.instance().start()
+    print 'starting'
+    application.listen(9090)
+    tornado.ioloop.IOLoop.instance().start()

--- a/server/server.py
+++ b/server/server.py
@@ -22,11 +22,21 @@ class WSHandler(tornado.websocket.WebSocketHandler):
 
     def open(self):
         print 'connection opened.'
-        WS_HANDLERS.append(self)
         self.write_message("The server graciously welcomes you.")
-        self.write_message("Here are the past messages...")
+        self.write_message("There are {} other people here".format(str(len(WS_HANDLERS))))
+
+        if MESSAGE_HISTORY:
+            self.write_message("Here are the past messages...")
+
+        # send a dump of the message history to the new client
         for message in MESSAGE_HISTORY:
             self.write_message(message)
+
+        # let everyone else know there's a new client
+        for ws_handler in WS_HANDLERS:
+            ws_handler.write_message("Someone joined.  There are now {} people here".format(str(len(WS_HANDLERS) + 1)))
+
+        WS_HANDLERS.append(self)
 
     def on_message(self, message):
 


### PR DESCRIPTION
## Summary of changes

### server.py
The server demo now maintains a list of open connections, and forwards messages received by a given client to all other connected clients.  This effectively means our demo server is now a chat service.

To fully understand what's happening here, I encourage you to read the [full file (with my changes)] (https://github.com/jonnykry/se329-project4/blob/d8ea74cbee8973920cf5811ea6d4576ac2a8df3e/server/server.py) rather than just the diff.


### board.py
Created a work-in-progress model of a Box Game board.  You can create an x by y board and claim edges on it.  Tracks which boxes have been claimed by mapping the top-left corner of each box to its owner 


@jonnykry @kaptainkohl  @gtharris

#### DEMO!
Here's a quick demo.  Note, there is a bug where a given message is recorded twice in the message history.  Not too concerned with that, because we won't have to maintain a message history in our application.

![preview](http://g.recordit.co/QpHtM9I9oi.gif)