### PR TITLE
Add ability to update player name, claim lines.  Better communication

### DIFF
--- a/server/boxd_api.py
+++ b/server/boxd_api.py
@@ -140,7 +140,8 @@ class SocketConnection(tornado.websocket.WebSocketHandler):
 
                 responses = []
 
-                if new_boxes is not None:
+                # TODO:  Have errors propagate to this method instead of returning None
+                if new_boxes is not None:  # None means an Error occurred. [] means there are no new boxes
 
                     responses.append(messages.LineClaimedMessage((p1r, p1c), (p2r, p2c), self.client_id))
 
@@ -149,8 +150,6 @@ class SocketConnection(tornado.websocket.WebSocketHandler):
 
                     for response in responses:
                         ConnectionManager.send_to_all(GameRunner.get_players_from_game(self.client_id), json.dumps(response.get_message()))
-
-
 
     def on_close(self):
 

--- a/server/game/boxd_game.py
+++ b/server/game/boxd_game.py
@@ -253,14 +253,14 @@ class Board(object):
             # check if the 3 lines necessary for a new box to exist are there
             if (self.__is_valid_edge(tblp, p1) and self.edge_is_owned(tblp, p1)) and \
                     (self.__is_valid_edge(tbrp, p2) and self.edge_is_owned(tbrp, p2))and \
-                    (self.__is_valid_edge(tblp, tbrp and self.edge_is_owned(tblp, tbrp))):
+                    (self.__is_valid_edge(tblp, tbrp) and self.edge_is_owned(tblp, tbrp)):
 
                 new_boxes.append(tblp)
 
             # check if the 3 lines necessary for a new box to exist are there
             if (self.__is_valid_edge(p1, bblp) and self.edge_is_owned(p1, bblp)) and \
                     (self.__is_valid_edge(p2, bbrp) and self.edge_is_owned(p2, bbrp))and \
-                    (self.__is_valid_edge(bblp, bbrp and self.edge_is_owned(bblp, bbrp))):
+                    (self.__is_valid_edge(bblp, bbrp) and self.edge_is_owned(bblp, bbrp)):
 
                 new_boxes.append(p1)
 

--- a/server/models/message.py
+++ b/server/models/message.py
@@ -1,0 +1,64 @@
+class Message(object):
+
+    def __init__(self, msg):
+        self.__message = msg
+
+    def get_message(self):
+        return self.__message
+
+
+class LineClaimedMessage(Message):
+
+    def __init__(self, point1, point2, owner):
+        if not (isinstance(point1, tuple) and isinstance(point2, tuple)):
+            raise ValueError("Point was not a tuple:  {}, {}".format(point1, point2))
+        # TODO:  change to what Jonny and Blake will be expecting
+        msg = {
+            'type': 'line_claimed',
+            'data': {
+                'point1': {
+                    'row': point1[0],
+                    'col': point1[1],
+                },
+                'point2': {
+                    'row': point2[0],
+                    'col': point2[1],
+                },
+                'owner': owner
+            }
+        }
+
+        super(LineClaimedMessage, self).__init__(msg)
+
+
+class BoxCreatedMessage(Message):
+
+    def __init__(self, corner_point, owner):
+        if not isinstance(corner_point, tuple):
+            raise ValueError("Point was not a tuple:  {}".format(corner_point))
+        # TODO:  change to what Jonny and Blake will be expecting
+        msg = {
+            'type': 'box_created',
+            'data': {
+                'corner': {
+                    'row': corner_point[0],
+                    'col': corner_point[1],
+                },
+                'owner': owner
+            }
+        }
+
+        super(BoxCreatedMessage, self).__init__(msg)
+
+
+class NameChangedMessage(Message):
+    def __init__(self, player_id, new_name):
+        # TODO:  change to what Jonny and Blake will be expecting
+        msg = {
+            'type': 'name_changed',
+            'data': {
+                'player': player_id,
+                'name': new_name}
+        }
+        super(NameChangedMessage, self).__init__(msg)
+

--- a/server/test/runner_test.py
+++ b/server/test/runner_test.py
@@ -68,5 +68,15 @@ class TestBoxdRunner(unittest.TestCase):
         self.assertEqual(GameRunner.get_player_ids(), [])
         self.assertEqual(GameRunner.running_games(), 0)
 
+    def test_updating_player_name(self):
+
+        client_id = "0"
+        GameRunner.assign_player(client_id)
+        self.assertEqual(GameRunner.get_player_name(client_id), "Unnamed Player")
+
+        GameRunner.update_player_name(client_id, "Bernie Sanders")
+        self.assertEqual(GameRunner.get_player_name(client_id), "Bernie Sanders")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
#### Summary of Changes
- Clients can now tell the backend that they wish to change their nicknames and claim lines on the board
- Other clients are now notified when a new client joins their game
- Other clients are now notified when a client leaves their game
- Added patterns for responses (see below)

**Request to change nickname**:  
```
{
  "type": "NICKNAME",
  "data": {
    "name": desired_name
  }
}
```
**Response for changing nickname (sent to all clients in the same game)**:  
```
{
  "type": "name_changed",
  "data": {
    "player": player_id_str
    "name": new_name
  }
}
```
**Request to claim a line**:
```
{
  "type": "CLAIM_LINE",  # TODO:  Make each point its own object
  "data":{
    "pt1_r": point_1_row,
    "pt1_c": point_1_col,
    "pt2_r": point_2_row, 
    "pt2_c": point_2_col
  }
}
```
**Response for a successful line claim (sent to all clients in the same game)**:
```
{
  "type": "line_claimed", 
  "data": {
    "point1": {
      "row": row
      "col": col
    },
    "point2":{
      "row": row
      "col": col
    },
    "owner": player_id_str
  }
}
```
**Response when backend notifies clients of a box creation (sent to all clients in a game)**:
```
{
  "type": "box_created",
  "data": {
    "corner": {
      "row": row,
      "col":  col
    },
    "owner", player_id_str
  }
}
```

#### Screenshots or Demo (optional)
![preview](http://g.recordit.co/4DrBVOXRYO.gif)

#### Code Reviewer(s)
@jonnykry  @kaptainkohl @gtharris

#### Build Status
[![Build Status](https://travis-ci.org/jonnykry/boxD.svg?branch=sam_dev)](https://travis-ci.org/jonnykry/boxD)

#### Relevant GIF
![preview2](http://www.reactiongifs.com/r/mmll.gif)