### PR TITLE
Sam dev

### DIFF
--- a/server/game/boxd_game.py
+++ b/server/game/boxd_game.py
@@ -38,10 +38,6 @@ class BoxdGame(object):
 
         try:
             return self.__board.claim_edge(pt1, pt2, player_id)
-        except EdgeOwnedError:
-            # this presumably means another client snagged the line first
-            # do we need to tell the client to redraw a line, or just rely on the other client's successful claim msg?
-            return None
 
         except ValueError:
             # line was somehow invalid


### PR DESCRIPTION
## [PR 14](https://github.com/jonnykry/boxD/pull/14) must merge before this PR
#### Summary of Changes


Added a `next_move` datetime field to the Player class. When a player successfully claims a line, their `next_move` attribute is set to 10 seconds later (`datetime.datetime.now() + datetime.timedelta(seconds=10)`)

When a player is in cool-off mode, all of their edge claims (valid or otherwise) are ignored until their cool-off is finished.

#### Screenshots or Demo (optional)
![preview](http://g.recordit.co/pVu2iG8cBy.gif)

#### Code Reviewer(s)
@jonnykry @kaptainkohl @gtharris 

#### Build Status
[![Build Status](https://travis-ci.org/jonnykry/boxD.svg?branch=sam_dev)](https://travis-ci.org/jonnykry/boxD)

#### Relevant GIF (How does this PR make you feel?)
![gif](http://3.bp.blogspot.com/-cFZW5VamoIY/Vm4C4Sl_O0I/AAAAAAAACFo/2iFw7z_pF30/s640/anigif_enhanced-buzz-10829-1389137938-8.gif)